### PR TITLE
Fix Command `/flare tps`

### DIFF
--- a/src/main/java/com/cleanroommc/flare/common/command/sub/component/tick/TPSCommand.java
+++ b/src/main/java/com/cleanroommc/flare/common/command/sub/component/tick/TPSCommand.java
@@ -67,7 +67,6 @@ public class TPSCommand extends FlareSubCommand {
             return;
         }
         TickStatistics stats = this.flare.tickStatistics(this.side, tickType);
-        sendMessage(sender, ChatUtil.RESET);
         sendMessage(sender, LangKeys.TPS_STATISTICS_RECALL,
                 StatisticFormatter.formatTps(stats.tps5Sec()),
                 StatisticFormatter.formatTps(stats.tps10Sec()),

--- a/src/main/java/com/cleanroommc/flare/common/command/sub/component/tick/TPSCommand.java
+++ b/src/main/java/com/cleanroommc/flare/common/command/sub/component/tick/TPSCommand.java
@@ -81,10 +81,6 @@ public class TPSCommand extends FlareSubCommand {
                 StatisticFormatter.formatCpuUsage(CpuMonitor.systemLoad10SecAvg()),
                 StatisticFormatter.formatCpuUsage(CpuMonitor.systemLoad1MinAvg()),
                 StatisticFormatter.formatCpuUsage(CpuMonitor.systemLoad15MinAvg()));
-        sendMessage(sender, LangKeys.CPU_USAGE_SYSTEM_LOAD,
-                StatisticFormatter.formatCpuUsage(CpuMonitor.processLoad10SecAvg()),
-                StatisticFormatter.formatCpuUsage(CpuMonitor.processLoad1MinAvg()),
-                StatisticFormatter.formatCpuUsage(CpuMonitor.processLoad15MinAvg()));
     }
 
 }

--- a/src/main/java/com/cleanroommc/flare/common/command/sub/component/tick/TPSCommand.java
+++ b/src/main/java/com/cleanroommc/flare/common/command/sub/component/tick/TPSCommand.java
@@ -67,6 +67,7 @@ public class TPSCommand extends FlareSubCommand {
             return;
         }
         TickStatistics stats = this.flare.tickStatistics(this.side, tickType);
+        sendMessage(sender, ChatUtil.RESET);
         sendMessage(sender, LangKeys.TPS_STATISTICS_RECALL,
                 StatisticFormatter.formatTps(stats.tps5Sec()),
                 StatisticFormatter.formatTps(stats.tps10Sec()),

--- a/src/main/java/com/cleanroommc/flare/common/command/sub/component/tick/TPSCommand.java
+++ b/src/main/java/com/cleanroommc/flare/common/command/sub/component/tick/TPSCommand.java
@@ -10,6 +10,7 @@ import com.cleanroommc.flare.util.StatisticFormatter;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
+import com.cleanroommc.flare.util.ChatUtil;
 import net.minecraftforge.fml.relauncher.Side;
 
 import javax.annotation.Nullable;
@@ -73,10 +74,12 @@ public class TPSCommand extends FlareSubCommand {
                 StatisticFormatter.formatTps(stats.tps5Min()),
                 StatisticFormatter.formatTps(stats.tps15Min()));
         if (stats.isDurationSupported()) {
+            sendMessage(sender, ChatUtil.RESET);
             sendMessage(sender, LangKeys.TPS_STATISTICS_DURATION_AVERAGES,
                     StatisticFormatter.formatTickDurations(stats.duration10Sec()),
                     StatisticFormatter.formatTickDurations(stats.duration1Min()));
         }
+        sendMessage(sender, ChatUtil.RESET);
         sendMessage(sender, LangKeys.CPU_USAGE_SYSTEM_LOAD,
                 StatisticFormatter.formatCpuUsage(CpuMonitor.systemLoad10SecAvg()),
                 StatisticFormatter.formatCpuUsage(CpuMonitor.systemLoad1MinAvg()),

--- a/src/main/resources/assets/flare/lang/en_us.lang
+++ b/src/main/resources/assets/flare/lang/en_us.lang
@@ -6,10 +6,10 @@ flare.message.tick_monitoring_end=§6Analysis is now complete.§r\n§f>§7 Max: 
 flare.message.tick_monitoring_report=§7Tick §8#%s §7lasted §6%s §7ms. (§6%s%% §7increased from average)
 flare.message.tick_monitoring_gc_report=§7Tick §8#%s §7included §4GC §7lasting §6%s §7ms. (Type = %s)
 flare.message.tick_monitoring_disabled=Tick monitor disabled.
-flare.message.tps_statistics_recall=TPS from the last 5s, 10s, 1m, 5m, 15m:\n%s, %s, %s, %s, %s\n
-flare.message.tps_statistics_duration_averages=Tick durations (min/med/95%%ile/max ms) from the last 10s, 1m:\n%s ; %s\n
-flare.message.cpu_usage_system_load=CPU usage from the last 10s, 1m, 15m:\n%s, %s, %s  §8(system)\n
-flare.message.cpu_usage_process_load=CPU usage from the last 10s, 1m, 15m:\n%s, %s, %s  §8(process)\n
+flare.message.tps_statistics_recall=TPS from the last 5s, 10s, 1m, 5m, 15m:\n%s, %s, %s, %s, %s
+flare.message.tps_statistics_duration_averages=Tick durations (min/med/95%%ile/max ms) from the last 10s, 1m:\n%s ; %s
+flare.message.cpu_usage_system_load=CPU usage from the last 10s, 1m, 15m:\n%s, %s, %s  §8(system)
+flare.message.cpu_usage_process_load=CPU usage from the last 10s, 1m, 15m:\n%s, %s, %s  §8(process)
 flare.message.ping_statistics_specific_player=Player §b%s§r has %sms ping.
 flare.message.ping_statistics_averages=Average pings (min/med/95%%ile/max ms) from now and last 15m:\n%s ; %s
 flare.message.basic_memory_usage_report=§6Memory Usage:§r\n    §f%s§r §7/ §f%s§r   §7(§a%s§7)§r\n    %s


### PR DESCRIPTION
1. remove the Duplicate CPU usage from on `/flare tps`, fix https://github.com/CleanroomMC/Flare/issues/12
2. remove the `\n` in langs. We add a empty line in codes. fix https://github.com/CleanroomMC/Flare/issues/13
3. This make the command prints shorter, may fix #14 . 